### PR TITLE
Add macOS universal binary build script (arm64 + x86_64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ The usage is:
 macres --export [file] [output_directory]
 ```
 
+## Building for macOS
+
+A build script is provided that produces a universal binary (native on both Apple Silicon and Intel Macs):
+
+```sh
+./build-scripts/build-macos-universal.sh
+```
+
+### Requirements
+- Xcode Command Line Tools: `xcode-select --install`
+- CMake 3.0+: `brew install cmake`
+
+### Notes
+- Steam support is excluded from this build (`-DSTEAM=OFF`). The SteamworksSDK submodule requires separate access. Steam features are available via the official [Steam release](https://store.steampowered.com/app/4239950/Maelstrom).
+- On first launch, macOS will prompt for permission to access your Documents folder. This is expected — SDL3's user storage API saves preferences and high scores there. Grant access to enable saving.
+
+The script outputs `Maelstrom.app` in the repository root. To install:
+```sh
+cp -r Maelstrom.app /Applications/
+```
+
 ## Porting to SDL3
 
 I did a short series of live-stream videos documenting the initial port from SDL2 to SDL3, available on YouTube:

--- a/build-scripts/build-macos-universal.sh
+++ b/build-scripts/build-macos-universal.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# build-macos-universal.sh — Build a universal (arm64 + x86_64) Maelstrom.app for macOS
+#
+# Tested on: Apple Mac Mini M4 (macOS Sequoia)
+# Built with the assistance of Claude Code (https://claude.ai/claude-code)
+#
+# Usage:
+#   ./build-scripts/build-macos-universal.sh [--output /path/to/output]
+#
+# Requirements:
+#   - Xcode Command Line Tools (xcode-select --install)
+#   - CMake 3.0+ (brew install cmake)
+#
+# Note: Steam support is excluded from this build. The SteamworksSDK submodule
+# requires separate access. Steam features are available via the official Steam release.
+#
+# Note: On first launch, macOS will prompt for permission to access your Documents
+# folder. This is expected — SDL3's user storage API saves preferences and high
+# scores there. Grant access to enable saving.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="${1:-$REPO_DIR}"
+
+# Parse --output argument
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output) OUTPUT_DIR="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+echo "==> Building Maelstrom universal macOS app"
+echo "    Repo:   $REPO_DIR"
+echo "    Output: $OUTPUT_DIR"
+echo ""
+
+# --- Prerequisites ---
+if ! command -v cmake &>/dev/null; then
+    echo "Error: cmake not found. Install with: brew install cmake"
+    exit 1
+fi
+
+if ! xcode-select -p &>/dev/null; then
+    echo "Error: Xcode Command Line Tools not found. Install with: xcode-select --install"
+    exit 1
+fi
+
+cd "$REPO_DIR"
+
+# --- Submodules ---
+echo "==> Initializing submodules (skipping SteamworksSDK)..."
+git submodule update --init external/SDL external/SDL_net external/physfs
+
+# SDL_net may need manual checkout if the working tree is empty
+if [ ! -f external/SDL_net/CMakeLists.txt ]; then
+    echo "    Manually checking out SDL_net..."
+    SDLNET_COMMIT=$(git submodule status external/SDL_net | awk '{print $1}' | tr -d '-')
+    GIT_WORK_TREE=external/SDL_net GIT_DIR=.git/modules/external/SDL_net \
+        git checkout "$SDLNET_COMMIT" -- .
+fi
+
+# --- Build arm64 ---
+echo ""
+echo "==> Configuring for arm64..."
+cmake -B build-arm64 \
+    -DCMAKE_OSX_ARCHITECTURES=arm64 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DSTEAM=OFF
+
+echo "==> Building for arm64..."
+cmake --build build-arm64 --config Release
+
+# --- Build x86_64 ---
+echo ""
+echo "==> Configuring for x86_64..."
+cmake -B build-x86_64 \
+    -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DSTEAM=OFF
+
+echo "==> Building for x86_64..."
+cmake --build build-x86_64 --config Release
+
+# --- Stage game data ---
+echo ""
+echo "==> Staging game data..."
+cmake --install build-arm64 --prefix stage
+
+# --- Create universal binaries ---
+echo ""
+echo "==> Creating universal binaries with lipo..."
+lipo -create \
+    build-arm64/Release/Maelstrom \
+    build-x86_64/Release/Maelstrom \
+    -output stage/Maelstrom
+
+lipo -create \
+    build-arm64/Release/libSDL3.0.dylib \
+    build-x86_64/Release/libSDL3.0.dylib \
+    -output stage/libSDL3.0.dylib
+
+# --- Assemble .app bundle ---
+echo ""
+echo "==> Assembling Maelstrom.app..."
+
+APP="$OUTPUT_DIR/Maelstrom.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+mkdir -p "$APP/Contents/Resources"
+
+# Binary and dylib go in MacOS/
+cp stage/Maelstrom "$APP/Contents/MacOS/"
+cp stage/libSDL3.0.dylib "$APP/Contents/MacOS/"
+
+# Game data goes in Resources/
+cp -r stage/Data "$APP/Contents/Resources/"
+cp -r stage/mods "$APP/Contents/Resources/"
+
+# Icon (sourced from Xcode assets)
+ICNS="$REPO_DIR/Xcode/Assets.xcassets/AppIcon.appiconset"
+if [ -f "$ICNS/maelstrom1024.png" ]; then
+    # Convert PNG to icns if iconutil is available
+    ICONSET=$(mktemp -d).iconset
+    mkdir -p "$ICONSET"
+    sips -z 16 16 "$ICNS/maelstrom1024.png" --out "$ICONSET/icon_16x16.png" &>/dev/null
+    sips -z 32 32 "$ICNS/maelstrom1024.png" --out "$ICONSET/icon_16x16@2x.png" &>/dev/null
+    sips -z 32 32 "$ICNS/maelstrom1024.png" --out "$ICONSET/icon_32x32.png" &>/dev/null
+    sips -z 64 64 "$ICNS/maelstrom1024.png" --out "$ICONSET/icon_32x32@2x.png" &>/dev/null
+    sips -z 128 128 "$ICNS/maelstrom1024.png" --out "$ICONSET/icon_128x128.png" &>/dev/null
+    sips -z 256 256 "$ICNS/maelstrom1024.png" --out "$ICONSET/icon_128x128@2x.png" &>/dev/null
+    sips -z 256 256 "$ICNS/maelstrom1024.png" --out "$ICONSET/icon_256x256.png" &>/dev/null
+    sips -z 512 512 "$ICNS/maelstrom1024.png" --out "$ICONSET/icon_256x256@2x.png" &>/dev/null
+    sips -z 512 512 "$ICNS/maelstrom1024.png" --out "$ICONSET/icon_512x512.png" &>/dev/null
+    cp "$ICNS/maelstrom1024.png" "$ICONSET/icon_512x512@2x.png"
+    iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/Maelstrom.icns"
+    rm -rf "$ICONSET"
+fi
+
+# Info.plist — substitute version from CMakeLists.txt
+MAJOR=$(grep "^set(MAJOR_VERSION" "$REPO_DIR/CMakeLists.txt" | grep -o '[0-9]*')
+MINOR=$(grep "^set(MINOR_VERSION" "$REPO_DIR/CMakeLists.txt" | grep -o '[0-9]*')
+MICRO=$(grep "^set(MICRO_VERSION" "$REPO_DIR/CMakeLists.txt" | grep -o '[0-9]*')
+VERSION="$MAJOR.$MINOR.$MICRO"
+
+sed "s/MAELSTROM_VERSION/$VERSION/g" \
+    "$REPO_DIR/build-scripts/macos/Info.plist" \
+    > "$APP/Contents/Info.plist"
+
+printf 'APPL????' > "$APP/Contents/PkgInfo"
+
+# --- Done ---
+echo ""
+echo "==> Done!"
+echo ""
+echo "    $APP"
+echo ""
+file "$APP/Contents/MacOS/Maelstrom"
+echo ""
+echo "To install, run:"
+echo "    cp -r \"$APP\" /Applications/"

--- a/build-scripts/macos/Info.plist
+++ b/build-scripts/macos/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>Maelstrom</string>
+	<key>CFBundleIconFile</key>
+	<string>Maelstrom.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.libsdl.Maelstrom</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Maelstrom</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>MAELSTROM_VERSION</string>
+	<key>CFBundleShortVersionString</key>
+	<string>MAELSTROM_VERSION</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds `build-scripts/build-macos-universal.sh` — a script that builds a universal (arm64 + x86_64) `Maelstrom.app` for macOS without requiring the Xcode IDE
- Adds `build-scripts/macos/Info.plist` — bundle metadata template with version substituted from `CMakeLists.txt` at build time
- Documents the build process and a first-launch behavior note in `README.md`

## Motivation

The existing Intel-only macOS build triggers an Apple deprecation warning on Apple Silicon Macs ("Support Ending for Intel-based Apps"). This script produces a proper universal binary that runs natively on both Apple Silicon and Intel, with no code changes required — the CMake build system already handled arm64 cleanly.

## How it works

1. Initializes required submodules (SDL, SDL_net, PhysFS — skips SteamworksSDK)
2. Configures and builds for `arm64` and `x86_64` separately via CMake (`-DSTEAM=OFF`)
3. Combines binaries and SDL3 dylib with `lipo`
4. Assembles a complete `.app` bundle with game data, icon, and version-stamped `Info.plist`

## Testing

Tested on **Apple Mac Mini M4 (macOS Tahoe 26.4.1)**. Game launches, plays, and saves preferences correctly. The universal binary runs natively on Apple Silicon; the x86_64 slice was compiled successfully but has not been tested on Intel hardware.

## Notes

- Steam support is excluded (`-DSTEAM=OFF`) as the SteamworksSDK submodule is not publicly accessible. This only affects the local build; the Steam release is unaffected.
- On first launch, macOS prompts for permission to access the Documents folder. This is expected behavior from SDL3's `SDL_OpenUserStorage` API (a change from SDL2, which used `~/Library/Application Support/` without prompting). Documented in the README.
- I'm not a developer — just a decades-long fan of the game who got the "Support Ending for Intel-based Apps" warning one too many times and had [Claude Code](https://claude.ai/claude-code) at my disposal. If anything here needs fixing or polish from someone who actually knows what they're doing, I'm happy to update the branch.

## Test plan

- [ ] Build script completes without errors on Apple Silicon Mac
- [ ] Build script completes without errors on Intel Mac
- [ ] Resulting `Maelstrom.app` launches and plays correctly on both architectures
- [ ] Preferences and high scores save correctly across sessions