### PR TITLE
Drop getifaddrs() leftovers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,20 +188,6 @@ else()
     target_compile_options(Maelstrom PRIVATE -Wno-unused-parameter)
 endif()
 
-if(NOT WIN32)
-  check_c_source_compiles("
-      #include <ifaddrs.h>
-      int main() {
-        struct ifaddrs* ifap;
-        getifaddrs(&ifap);
-        return 0;
-      }
-    " HAVE_GETIFADDRS)
-  if(HAVE_GETIFADDRS)
-    target_compile_definitions(Maelstrom PRIVATE HAVE_GETIFADDRS)
-  endif()
-endif()
-
 dep_option(STEAM "Build with Steam support" ON "WIN32 OR LINUX OR MACOS" OFF)
 
 if(STEAM)

--- a/game/lobby.cpp
+++ b/game/lobby.cpp
@@ -34,16 +34,6 @@
 #include <iphlpapi.h>
 #endif
 
-#ifdef SDL_PLATFORM_APPLE
-#ifndef HAVE_GETIFADDRS
-#define HAVE_GETIFADDRS
-#endif
-#endif
-#ifdef HAVE_GETIFADDRS
-#include <ifaddrs.h>
-#include <netinet/in.h>
-#endif
-
 
 class SelectControlCallback : public UIClickCallback
 {


### PR DESCRIPTION
Commit 8c5feb3cac6ee8fe2e160f7073450ed49235ea11 dropped the usage of `getifaddrs()` on non-Windows OSes, so drop the now unused includes and build system check for it.